### PR TITLE
Include Dockerfile in version control for Render deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,3 @@ backend/.env
 *.swp
 .env
 .env.*
-
-# Docker
-**/.dockerignore
-**/Dockerfile
-**/docker-compose.yml

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+*.sqlite3
+venv/
+.env
+.env.*
+.vscode/
+.idea/
+*.swp
+*.log
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
This PR adds the Dockerfile to version control, enabling proper container-based deployment of the FastAPI backend via Render. The Dockerfile was previously ignored and is now tracked to ensure compatibility with the platform's Docker build process.

Changes included:

Removed Dockerfile from .gitignore

Committed Dockerfile to repository

This update is essential for the deployment pipeline and aligns with the best practices for containerized applications.